### PR TITLE
Fix build against newer vcglib

### DIFF
--- a/vcgmesh.cpp
+++ b/vcgmesh.cpp
@@ -214,7 +214,11 @@ int VcgMesh::simplify(int percFaces){
   qparams.PreserveBoundary	= false;
   qparams.PreserveTopology	= false;
   //qparams.PreserveBoundaryMild	= false ;
-  qparams.BoundaryWeight  = 500;
+  // BoundaryWeight is now split into BoundaryQuadricWeight and QualityQuadricWeight where:
+  // BoundaryQuadricWeight = BoundaryWeight
+  // QualityQuadricWeight  = BoundaryWeight / 100
+  qparams.BoundaryQuadricWeight = 500;
+  qparams.QualityQuadricWeight = qparams.BoundaryQuadricWeight / 100;
 
 
   //qparams.QualityThr	= atof(argv[i]+2);


### PR DESCRIPTION
split BoundaryWeight into BoundaryQuadricWeight and QualityQuadricWeight

old: https://github.com/cnr-isti-vclab/vcglib/blob/a8e87662b63ee9f4ded5d4699b28d74183040803/vcg/complex/algorithms/local_optimization/tri_edge_collapse_quadric.h#L491
new: https://github.com/cnr-isti-vclab/vcglib/blob/e4950d12e2db7f6ec3e587b06b2a0474b4f08d96/vcg/complex/algorithms/local_optimization/tri_edge_collapse_quadric.h#L590